### PR TITLE
fix: correct category GraphQL mutations to match Monarch API schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1899,6 +1900,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2068,6 +2070,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2374,6 +2377,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -2873,6 +2877,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2929,6 +2934,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3528,6 +3534,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -3866,6 +3873,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5095,6 +5103,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5798,6 +5807,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
### **User description**
## Summary
Fixes 400 Bad Request errors when using category CRUD operations by correcting the GraphQL mutations to match Monarch Money's actual API schema.

## Changes
- **createCategory**: Use `Web_CreateCategory` mutation with `CreateCategoryInput` and required `PayloadErrorFields`/`CategoryFormFields` fragments
- **deleteCategory**: Use `Web_DeleteCategory` mutation with correct format and fragments  
- **getCategoryGroups**: Use `ManageGetCategoryGroups` query with `categoryGroups` field

## How I Found the Correct Format
The mutations were reverse-engineered from the official [Python monarchmoney library](https://github.com/hammem/monarchmoney) which has working implementations. GraphQL introspection is disabled for non-admin users, so the Python library was the best reference.

## Testing
- Tested createCategory - successfully creates categories
- Tested deleteCategory - successfully deletes categories
- Tested getCategoryGroups - successfully returns category groups


___

### **PR Type**
Bug fix


___

### **Description**
- Corrects GraphQL mutations to match Monarch Money API schema

- Updates `createCategory` with proper mutation name and input format

- Updates `deleteCategory` with correct mutation signature and parameters

- Fixes `getCategoryGroups` query to use correct field names

- Adds required GraphQL fragments for error handling and category fields


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old GraphQL Mutations"] -->|"Incorrect schema"| B["400 Bad Request"]
  C["Monarch API Schema"] -->|"Reference from Python library"| D["Corrected Mutations"]
  D -->|"Web_CreateCategory"| E["createCategory"]
  D -->|"Web_DeleteCategory"| F["deleteCategory"]
  D -->|"ManageGetCategoryGroups"| G["getCategoryGroups"]
  E --> H["Success"]
  F --> H
  G --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CategoriesAPI.ts</strong><dd><code>Align category mutations with Monarch Money API schema</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/api/categories/CategoriesAPI.ts

<ul><li>Updated <code>createCategory</code> mutation from <code>CreateTransactionCategory</code> to <br><code>Web_CreateCategory</code> with <code>CreateCategoryInput</code> type<br> <li> Added <code>PayloadErrorFields</code> and <code>CategoryFormFields</code> GraphQL fragments for <br>proper response handling<br> <li> Modified input object to match Monarch's expected format with <code>group</code>, <br><code>icon</code>, <code>rolloverEnabled</code>, <code>rolloverType</code>, and <code>rolloverStartMonth</code> fields<br> <li> Updated <code>deleteCategory</code> mutation from <code>DeleteTransactionCategory</code> to <br><code>Web_DeleteCategory</code> with optional <code>moveToCategoryId</code> parameter<br> <li> Changed <code>getCategoryGroups</code> query from <code>GetTransactionCategoryGroups</code> to <br><code>ManageGetCategoryGroups</code> with updated field names<br> <li> Added validation for required <code>groupId</code> parameter in <code>createCategory</code><br> <li> Updated error handling to match new response structure with <br><code>PayloadError</code> type</ul>


</details>


  </td>
  <td><a href="https://github.com/keithah/monarchmoney-ts/pull/6/files#diff-af2bdb0a8d13a4379886cc45ececfd8657ea72ca6350c935c80a92d56cc5add6">+94/-58</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

